### PR TITLE
Fixing the problem where density has neglible effect on mass sampling

### DIFF
--- a/common_stuff.py
+++ b/common_stuff.py
@@ -467,6 +467,8 @@ def _sample_halos(
                     m_haloes = np.append(m_haloes, np.interp(rn_new, np.flip(N_cs), np.flip(mx[inds])))
             elif np.log10(np.sum(m_haloes)) > np.log10(mass_coll) - mass_range and np.log10(np.sum(m_haloes)) < np.log10(mass_coll) + mass_range:
                 break
+    print(m_haloes)
+    print("I need to know what I'm dealing with")
     m_haloes = np.concatenate(m_haloes)
     N = len(m_haloes)
     return N, m_haloes

--- a/common_stuff.py
+++ b/common_stuff.py
@@ -467,9 +467,11 @@ def _sample_halos(
                     m_haloes = np.append(m_haloes, np.interp(rn_new, np.flip(N_cs), np.flip(mx[inds])))
             elif np.log10(np.sum(m_haloes)) > np.log10(mass_coll) - mass_range and np.log10(np.sum(m_haloes)) < np.log10(mass_coll) + mass_range:
                 break
-    print(m_haloes, flush=True)
-    print("I need to know what I'm dealing with", flush=True)
-    m_haloes = np.concatenate(m_haloes)
+
+    try:
+        m_haloes = np.concatenate(m_haloes)
+    except ValueError:
+        pass
     N = len(m_haloes)
     return N, m_haloes
 

--- a/common_stuff.py
+++ b/common_stuff.py
@@ -467,8 +467,8 @@ def _sample_halos(
                     m_haloes = np.append(m_haloes, np.interp(rn_new, np.flip(N_cs), np.flip(mx[inds])))
             elif np.log10(np.sum(m_haloes)) > np.log10(mass_coll) - mass_range and np.log10(np.sum(m_haloes)) < np.log10(mass_coll) + mass_range:
                 break
-    print(m_haloes)
-    print("I need to know what I'm dealing with")
+    print(m_haloes, flush=True)
+    print("I need to know what I'm dealing with", flush=True)
     m_haloes = np.concatenate(m_haloes)
     N = len(m_haloes)
     return N, m_haloes

--- a/run.py
+++ b/run.py
@@ -80,6 +80,11 @@ if __name__ == '__main__':
         "--density_distribution",
         action="store_false"
     )
+    parser.add_argument(
+        "--mass_sampler",
+        type=str,
+        default='binning'
+    )
     inputs = parser.parse_args()
     assert inputs.control_run!= True or inputs.use_previous_run=='False', "Not compatible combination"
 
@@ -234,11 +239,8 @@ if __name__ == '__main__':
             processes=[]
             #pool = Pool(inputs.n_processes )
             for iter_num in range(int(inputs.N_iter / iter_per_par)):
-                print("big iter num", iter_num, flush=True)
-                if iter_num>10:
-                    assert False
+
                 with Pool(processes=inputs.n_processes) as pool:
-                
 
                     if inputs.wavelength == 'all':
                         time_start_sampling = time.time()
@@ -262,40 +264,51 @@ if __name__ == '__main__':
                         #for proc in psutil.process_iter():
                         #    print(proc.open_files())
                         #assert 1==0, "at least got here"
-                        results = [pool.apply_async(sampler_all_func,
-                                                   kwds = {
-                                                       'emissivities_x_list': emissivities_x,
-                                                       'emissivities_lw_list': emissivities_lw,
-                                                       'emissivities_uv_list': emissivities_uv,
-                                                       'z': z,
-                                                       'dlog10m': inputs.dlog10m,
-                                                       'N_iter': iter_per_par,
-                                                       'r_bias': inputs.R_bias,
-                                                       'log10_m_min': 5.0,
-                                                       'mass_binning': 1,
-                                                       'sample_hmf': sample_Poiss,
-                                                       'sample_SFR': sample_SFR,
-                                                       'sample_emiss': sample_emiss,
-                                                       'sample_met' : sample_met,
-                                                       'sample_Mstar': sample_Mstar,
-                                                       'bpass_read': bpass_read,
-                                                       'filename': filename,
-                                                       'control_run': inputs.control_run,
-                                                       'f_esc_option': inputs.f_esc_option,
-                                                       'proc_number': i,
-                                                       'get_previous': inputs.use_previous_run,
-                                                       'density_inst': delta_list[(iter_num * iter_per_par) : ((iter_num+1) * iter_per_par), i],
-                                                       'hmf_this': hmf_this,
-                                                       'SFH_samp': SFH_samp,
-                                                       'iter_num': iter_num,
-                                                       'shift_scaling': shift_scaling,
-                                                       'literature_run': inputs.literature_run,
-                                                       'flattening': inputs.flattening,
-                                                       'sample_densities': inputs.density_distribution
-                                         })
-                                 #        callback=saving_function,
-                        #                 error_callback = error_function,
-                             for i in range(inputs.n_processes-1)
+                        results = [
+                            pool.apply_async(
+                                sampler_all_func,
+                                kwds={
+                                    'emissivities_x_list': emissivities_x,
+                                    'emissivities_lw_list': emissivities_lw,
+                                    'emissivities_uv_list': emissivities_uv,
+                                    'z': z,
+                                    'dlog10m': inputs.dlog10m,
+                                    'N_iter': iter_per_par,
+                                    'r_bias': inputs.R_bias,
+                                    'log10_m_min': 5.0,
+                                    'mass_binning': 1,
+                                    'sample_hmf': sample_Poiss,
+                                    'sample_SFR': sample_SFR,
+                                    'sample_emiss': sample_emiss,
+                                    'sample_met' : sample_met,
+                                    'sample_Mstar': sample_Mstar,
+                                    'bpass_read': bpass_read,
+                                    'filename': filename,
+                                    'control_run': inputs.control_run,
+                                    'f_esc_option': inputs.f_esc_option,
+                                    'proc_number': i,
+                                    'get_previous': inputs.use_previous_run,
+                                    'density_inst': delta_list[
+                                                    (
+                                                        iter_num * iter_per_par
+                                                    ):(
+                                                        (
+                                                            iter_num+1
+                                                        ) * iter_per_par
+                                                    ),
+                                                    i
+                                                    ],
+                                    'hmf_this': hmf_this,
+                                    'SFH_samp': SFH_samp,
+                                    'iter_num': iter_num,
+                                    'shift_scaling': shift_scaling,
+                                    'literature_run': inputs.literature_run,
+                                    'flattening': inputs.flattening,
+                                    'sample_dens': inputs.density_distribution,
+                                    'mass_sampler': inputs.mass_sampler
+                                }
+                            )
+                            for i in range(inputs.n_processes-1)
                         ]
                         saving_function([j for i in results for j in i.get()])
                         time_end_sampling = time.time()

--- a/run.py
+++ b/run.py
@@ -234,6 +234,9 @@ if __name__ == '__main__':
             processes=[]
             #pool = Pool(inputs.n_processes )
             for iter_num in range(int(inputs.N_iter / iter_per_par)):
+                print("big iter num", iter_num, flush=True)
+                if iter_num>10:
+                    assert False
                 with Pool(processes=inputs.n_processes) as pool:
                 
 

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -485,7 +485,9 @@ def sampler_all_func(
             #    F_LW *= f_esc
             ###################END OF F_ESC FOR LW##############################
             #######################STAR OF F_ESC FOR UV#########################
-
+            print("Checking whether I reach the escape fraction", metalicity_samples,
+                  flush=True)
+            assert False
             if f_esc_option == 'binary':
                 if sample_emiss:
                     f_esc = fesc_distr()
@@ -571,6 +573,5 @@ def sampler_all_func(
     #container.add_LW(emissivities_lw)
     #container.add_UV(emissivities_uv)
   #  container = None
-    print("Checking whether I reach the end", list_of_outputs, flush=True)
-    assert False
+
     return list_of_outputs

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -175,7 +175,7 @@ def sampler_all_func(
                                                  V_bias,
                                                  mode='binning',
                                                  Poisson=sample_hmf,
-                                                 n_bins = 2,
+                                                 nbins=2,
                                                  mass_coll=None,
                                                  mass_range=None,
                                                  max_iter=None,
@@ -201,7 +201,7 @@ def sampler_all_func(
             setattr(class_int, 'redshift', z)
             n_this_iter, mhs = _get_loaded_halos(
                 z,
-                direc = '/home/inikolic/projects/stochasticity/_cache'
+                direc='/home/inikolic/projects/stochasticity/_cache'
             )
         elif get_previous!='False':
             with h5py.File('/home/inikolic/projects/stochasticity/_cache/Mh_'+get_previous+'.h5','r') as f_prev:

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -221,7 +221,7 @@ def sampler_all_func(
         time_2 = time.time()
         #print("Got masses now", time_2 - time_1)
 
-        print( n_this_iter, mhs )
+        print( n_this_iter, mhs, flush=True )
         assert False
         if not mass_binning:
             n_this_iter = N_mean

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -166,8 +166,6 @@ def sampler_all_func(
             m_min_temp = 7.6
             
             mass_coll = hmf_this.mass_coll_grt_st(delta_bias, mass=m_min_temp)
-            print(m_min_temp, sample_hmf, mass_func, log10_m_max, V_bias)
-            assert False
             if mass_binning:
                 n_this_iter, mhs = _sample_halos(masses[:len(mass_func)],
                                                  mass_func,
@@ -222,6 +220,9 @@ def sampler_all_func(
             n_this_iter = int(n_this_iter)
         time_2 = time.time()
         #print("Got masses now", time_2 - time_1)
+
+        print( n_this_iter, mhs )
+        assert False
         if not mass_binning:
             n_this_iter = N_mean
             masses_of_haloes = np.zeros(shape = n_this_iter)

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -177,7 +177,6 @@ def sampler_all_func(
                                                  mode='mass',
                                                  Poisson=sample_hmf,
                                                  mass_coll=mass_coll,
-                                                 max_iter=None,
                                                  )
 
                 if np.sum(mhs) < 0.5 * mass_coll:

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -221,8 +221,7 @@ def sampler_all_func(
         time_2 = time.time()
         #print("Got masses now", time_2 - time_1)
 
-        print( n_this_iter, mhs, flush=True )
-        assert False
+
         if not mass_binning:
             n_this_iter = N_mean
             masses_of_haloes = np.zeros(shape = n_this_iter)
@@ -572,5 +571,6 @@ def sampler_all_func(
     #container.add_LW(emissivities_lw)
     #container.add_UV(emissivities_uv)
   #  container = None
-    #print(list_of_outputs)
+    print("Checking whether I reach the end", list_of_outputs, flush=True)
+    assert False
     return list_of_outputs

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -554,12 +554,13 @@ def sampler_all_func(
         setattr(class_int, 'SFH', np.array(SFH_array))
 
         list_of_outputs.append(class_int)
-        print("Checking whether I reach the end of one iteration",
-              list_of_outpus,
-              flush=True)
-        assert False
+        print("Number of iteration", i, flush=True)
         #container.add_SFH(SFH_array)
-
+        if i>100:
+            print("Checking whether I reach the end of hundred iteration",
+                  list_of_outputs,
+                  flush=True)
+            assert False
     #    emissivities_x[i] = np.sum(L_X)
     #    emissivities_uv[i] = np.sum(L_UV)
     #    emissivities_lw[i] = np.sum(L_LW)

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -38,11 +38,10 @@ def sampler_all_func(
         dlog10m=0.01,
         N_iter=1000,
         sample_hmf=True,
-        sample_densities=True,
+        sample_dens=True,
         sample_SFR=True,
         sample_emiss=True,
         sample_met=True,
-        calculate_2pcc = False,     #2pcc correction to # of halos.
         duty_cycle=True,          #whether to turn of duty cycle.
         sample_Mstar=True,
         mass_binning=False,     #bin halo mass fucntion
@@ -59,6 +58,7 @@ def sampler_all_func(
         shift_scaling=False,
         literature_run=None,
         flattening=True,
+        mass_sampler='binning',
 ):
 
     M_turn = 5*10**8  #Park+19 parametrization
@@ -82,7 +82,7 @@ def sampler_all_func(
     #     '/home/inikolic/projects/stochasticity/samples/dir_080323/full/'
     # )
 
-    if sample_densities and not control_run and not get_previous:
+    if sample_dens and not control_run and not get_previous:
         pass
     #
     #     delta_list = _sample_densities(z,
@@ -95,7 +95,7 @@ def sampler_all_func(
     #     hmf_this = chmf(z=z, delta_bias=delta_bias, R_bias = R_bias)
     #     hmf_this.prep_for_hmf_st(log10_Mmin, log10_Mmax, dlog10m)
 
-    elif not sample_densities and not control_run and get_previous=='False':
+    elif not sample_dens and not control_run and get_previous=='False':
 
         if delta_bias==0.0:
             pass #this I haven't used for 2 years so I don't think I should be.
@@ -172,10 +172,10 @@ def sampler_all_func(
                                                  m_min_temp,
                                                  log10_m_max,
                                                  V_bias,
-                                                 mode='binning',
+                                                 mode=mass_sampler,
                                                  Poisson=sample_hmf,
                                                  nbins=2,
-                                                 mass_coll=None,
+                                                 mass_coll=mass_coll,
                                                  mass_range=None,
                                                  max_iter=None,
                                                  )
@@ -511,7 +511,6 @@ def sampler_all_func(
                 else:
                     F_LyC *= 10**f_esc
             SFH_samples.append(bpass_read.SFH)
-            print("iteration", j)
             L_X[j] = Lx_sample
             L_UV[j] = F_UV
             L_LW[j] = F_LW
@@ -554,7 +553,6 @@ def sampler_all_func(
         setattr(class_int, 'SFH', np.array(SFH_array))
 
         list_of_outputs.append(class_int)
-        print("Number of iteration", i, flush=True)
         #container.add_SFH(SFH_array)
 
     #    emissivities_x[i] = np.sum(L_X)

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -166,7 +166,8 @@ def sampler_all_func(
             m_min_temp = 7.6
             
             mass_coll = hmf_this.mass_coll_grt_st(delta_bias, mass=m_min_temp)
-
+            print(m_min_temp, sample_hmf, mass_func, log10_m_max, V_bias)
+            assert False
             if mass_binning:
                 n_this_iter, mhs = _sample_halos(masses[:len(mass_func)],
                                                  mass_func,

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -163,40 +163,42 @@ def sampler_all_func(
                     break
             masses=masses[:index_to_stop]
             mass_func=mass_func[:index_to_stop]
-            #######################TEMPORARY MINIMUM MASS#######################
-            Mmin_temp = 7.6
+
+            m_min_temp = 7.6
             
-            mass_coll = hmf_this.mass_coll_grt_ST(delta_bias, mass=Mmin_temp)
+            mass_coll = hmf_this.mass_coll_grt_st(delta_bias, mass=m_min_temp)
+
             if mass_binning:
-                N_this_iter, mhs = _sample_halos(masses[:len(mass_func)],
+                n_this_iter, mhs = _sample_halos(masses[:len(mass_func)],
                                                  mass_func,
-                                                 Mmin_temp,
+                                                 m_min_temp,
                                                  log10_m_max,
                                                  V_bias,
-                                                 mode = 'binning',
-                                                 Poisson = sample_hmf,
-                                                 nbins = 2,
-                                                 mass_coll = None,
-                                                 mass_range = None,
-                                                 max_iter = None,
+                                                 mode='mass',
+                                                 Poisson=sample_hmf,
+                                                 mass_coll=mass_coll,
+                                                 max_iter=None,
                                                  )
-                #print(mhs)
-                time_for_halo_sampling = time.time()
-                #    np.savetxt('/home/inikolic/projects/stochasticity/samples/halos{}.txt'.format(delta_bias), np.array(mhs))
-                     #print("Here's one file for you to analyze", flush=True)
-                if np.sum(mhs) < 0.5 *  mass_coll:
-                    #print("minimal temperature", Mmin_temp, "log10_Mmax", log10_Mmax,"mass_binning", mass_binning, "redshift", z)
-                    print( len(masses), sep=", ")
-                    print( len(mass_func), sep=", ")
-                    print(np.sum(mhs),mass_coll, V_bias, sample_hmf, "These are the ingredients", delta_bias, "and the previous number is delta")
-                    #raise ValueError("For this iteration sampling halos failed")
-                #assert len(mhs) < 1, "only one mass, aborting"
+
+                if np.sum(mhs) < 0.5 * mass_coll:
+                    print(len(masses), sep=", ")
+                    print(len(mass_func), sep=", ")
+                    print(
+                        np.sum(mhs),
+                        mass_coll,
+                        V_bias,
+                        sample_hmf,
+                        "These are the ingredients",
+                        delta_bias,
+                        "and the previous number is delta"
+                    )
+
         elif control_run:
             fake_delta = float(str(iter_num) + str(os.getpid()))
             class_int = Sampler_Output(fake_delta)
             setattr(class_int, 'filename', filename)
             setattr(class_int, 'redshift', z)
-            N_this_iter, mhs = _get_loaded_halos(
+            n_this_iter, mhs = _get_loaded_halos(
                 z,
                 direc = '/home/inikolic/projects/stochasticity/_cache'
             )
@@ -210,19 +212,19 @@ def sampler_all_func(
                 setattr(class_int, 'filename', filename)
                 setattr(class_int, 'redshift', z)
                 mhs = np.array(f_prev[str(z)][str(float(proc_number))][str(float(iter_num * N_iter + i))]['Mh'])
-                N_this_iter = len(mhs)
+                n_this_iter = len(mhs)
                 if len(mhs)==1 and mhs == np.zeros((1,)):
                     mhs = []
-                    N_this_iter = 0
+                    n_this_iter = 0
             #print("Time for mass sampling", time_is_now - time_is_up)
-            N_this_iter = int(N_this_iter)
+            n_this_iter = int(n_this_iter)
         time_2 = time.time()
         #print("Got masses now", time_2 - time_1)
         if not mass_binning:
-            N_this_iter = N_mean
-            masses_of_haloes = np.zeros(shape = N_this_iter)
+            n_this_iter = N_mean
+            masses_of_haloes = np.zeros(shape = n_this_iter)
                             
-            for ind, rn in enumerate(range(N_this_iter)):
+            for ind, rn in enumerate(range(n_this_iter)):
                 rand = np.random.uniform()
                 mhs[ind] = np.interp(rand, np.flip(N_cs_norm), np.flip(masses))
         

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -130,19 +130,18 @@ def sampler_all_func(
         
     #emissivities_x = np.zeros(shape = int(N_iter))
     #emissivities_lw = np.zeros(shape = int(N_iter))
-    #emissivities_uv = np.zeros(shape = int(N_iter))
-    #tot_mass = np.zeros(shape=int(N_iter))
-    time_1 = time.time()
-    #print("First checkpoint, before for loop", time_1 - time_0)
+    # emissivities_uv = np.zeros(shape = int(N_iter))
+    # tot_mass = np.zeros(shape=int(N_iter))
+    # print("First checkpoint, before for loop", time_1 - time_0)
     list_of_outputs = []
 
-    #print("Starting the iteration", flush=True)
+    # print("Starting the iteration", flush=True)
     for i in range(N_iter):
-        #assert i>0, "start iterations"
-        start = time.time()
+        # assert i>0, "start iterations"
+
         if not control_run and get_previous=='False':
 
-            #new 06/04/23: this is Lagrangian density at z=z going into chmf.
+            # new 06/04/23: this is a Lagrangian density at z=z going into chmf.
             if hasattr(density_inst, '__len__'):
                 delta_bias = density_inst[i]
             else:
@@ -174,9 +173,12 @@ def sampler_all_func(
                                                  m_min_temp,
                                                  log10_m_max,
                                                  V_bias,
-                                                 mode='mass',
+                                                 mode='binning',
                                                  Poisson=sample_hmf,
-                                                 mass_coll=mass_coll,
+                                                 n_bins = 2,
+                                                 mass_coll=None,
+                                                 mass_range=None,
+                                                 max_iter=None,
                                                  )
 
                 if np.sum(mhs) < 0.5 * mass_coll:

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -516,10 +516,7 @@ def sampler_all_func(
             L_UV[j] = F_UV
             L_LW[j] = F_LW
             L_LyC[j] = F_LyC
-        print("Checking whether I reach the end of the loop",
-              L_LyC,
-              flush=True)
-        assert False
+
         #M_uv = get_Muv(L_UV, solar_mult=True)
         #UV_lf, _ = get_uvlf(M_uv, Rbias=R_bias)
         setattr(class_int, 'stellar_masses', Mstar_samples)
@@ -557,7 +554,10 @@ def sampler_all_func(
         setattr(class_int, 'SFH', np.array(SFH_array))
 
         list_of_outputs.append(class_int)
-
+        print("Checking whether I reach the end of one iteration",
+              list_of_outpus,
+              flush=True)
+        assert False
         #container.add_SFH(SFH_array)
 
     #    emissivities_x[i] = np.sum(L_X)

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -556,11 +556,7 @@ def sampler_all_func(
         list_of_outputs.append(class_int)
         print("Number of iteration", i, flush=True)
         #container.add_SFH(SFH_array)
-        if i>100:
-            print("Checking whether I reach the end of hundred iteration",
-                  list_of_outputs,
-                  flush=True)
-            assert False
+
     #    emissivities_x[i] = np.sum(L_X)
     #    emissivities_uv[i] = np.sum(L_UV)
     #    emissivities_lw[i] = np.sum(L_LW)

--- a/sampler_all.py
+++ b/sampler_all.py
@@ -485,9 +485,7 @@ def sampler_all_func(
             #    F_LW *= f_esc
             ###################END OF F_ESC FOR LW##############################
             #######################STAR OF F_ESC FOR UV#########################
-            print("Checking whether I reach the escape fraction", metalicity_samples,
-                  flush=True)
-            assert False
+
             if f_esc_option == 'binary':
                 if sample_emiss:
                     f_esc = fesc_distr()
@@ -513,12 +511,15 @@ def sampler_all_func(
                 else:
                     F_LyC *= 10**f_esc
             SFH_samples.append(bpass_read.SFH)
-
+            print("iteration", j)
             L_X[j] = Lx_sample
             L_UV[j] = F_UV
             L_LW[j] = F_LW
             L_LyC[j] = F_LyC
-
+        print("Checking whether I reach the end of the loop",
+              L_LyC,
+              flush=True)
+        assert False
         #M_uv = get_Muv(L_UV, solar_mult=True)
         #UV_lf, _ = get_uvlf(M_uv, Rbias=R_bias)
         setattr(class_int, 'stellar_masses', Mstar_samples)


### PR DESCRIPTION
There is a problem where density distribution doesn't seem to influence emissivity distribution. This is clearly seen in the following pdf where green crosses mark the case where density distribution is not taken into account, and there is no change in mean or sigma.

[X_varmean_nodens.pdf](https://github.com/IvanNikolic21/Stochasticity_sampler/files/15131295/X_varmean_nodens.pdf)

The plan of this pull request is to test why that might be the case. First I'll run a few dedicated tests which require minor code changes.
