### PR TITLE
Dealing with h5py if there is already a file present

### DIFF
--- a/run.py
+++ b/run.py
@@ -191,7 +191,12 @@ if __name__ == '__main__':
 
     for index,z in enumerate(np.linspace(inputs.z_init,inputs.z_end,inputs.z_steps)):
         f = h5py.File(filename, 'a')
-        f.create_group(str(z))
+        try:
+            f.create_group(str(z))
+        except ValueError:
+            if dict(f[str(z)].attrs.keys()):
+                print(dict(f[str(z)].attrs.keys()))
+                raise ValueError("Trying to overwrite the file")
         f.close()
 
         SFH_samp = SFH_sampler(z)


### PR DESCRIPTION
This is a long-standing problem, with a very easy solution. Just check if there is stuff inside the h5py file, if there's not, continue, and if there is re-raise the Error.